### PR TITLE
NON-TASK: Removed hashing from password inputs

### DIFF
--- a/__tests__/auth/login/login.test.tsx
+++ b/__tests__/auth/login/login.test.tsx
@@ -7,10 +7,6 @@ jest.mock('@/lib/auth/login/actions', () => ({
   handleLoginFormSubmit: jest.fn(),
 }));
 
-jest.mock('@/lib/auth', () => ({
-  hashPassword: jest.fn().mockResolvedValue('hashedPassword'),
-}));
-
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(() => ({
     push: jest.fn(),
@@ -32,7 +28,6 @@ const mockFailedLoginResponse = jest.fn().mockResolvedValue({
   ok: false,
   message: "Invalid credentials",
 });
-
 
 describe("Login Page", () => {
   const mockRouter = {
@@ -71,7 +66,7 @@ describe("Login Page", () => {
     await waitFor(() => {
       expect(handleLoginFormSubmit).toHaveBeenCalledWith({
         phone_number: "08123456789",
-        password: "hashedPassword",
+        password: "mypassword123",
       });
       expect(mockRouter.push).toHaveBeenCalledWith("/");
     });

--- a/__tests__/auth/register/page.test.tsx
+++ b/__tests__/auth/register/page.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import RegisterPage from '@/app/auth/register/page';
-import { handleRegisterSubmit, hashPassword } from '@/lib/auth';
+import { handleRegisterSubmit } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
 
 jest.mock('@/lib/auth', () => ({
   handleRegisterSubmit: jest.fn(),
-  hashPassword: jest.fn().mockResolvedValue('hashedPassword'),
 }));
 
 jest.mock('next/navigation', () => ({
@@ -69,7 +68,6 @@ describe("Register Page", () => {
   });
 
   it("allows user to register and succeeds the submission", async () => {
-    (hashPassword as jest.Mock).mockResolvedValue('hashedPassword123');
     (handleRegisterSubmit as jest.Mock).mockResolvedValue({ok: true, message:"Registrasi berhasil"})
     
     fireEvent.change(phoneInput, { target: { value: '08123456789' } });
@@ -82,12 +80,11 @@ describe("Register Page", () => {
     })
 
     await waitFor(() => {
-      expect(hashPassword).toHaveBeenCalledWith('mypassword123')
       expect(handleRegisterSubmit).toHaveBeenCalledWith({
         phone_number: '08123456789',
         first_name: 'John',
         last_name: 'Doe',
-        password: 'hashedPassword123'
+        password: 'mypassword123'
       });
       expect(mockPush).toHaveBeenCalledWith("/")
     });
@@ -112,7 +109,6 @@ describe("Register Page", () => {
 
   it("shows error message when registration fails", async () => {
     (handleRegisterSubmit as jest.Mock).mockImplementationOnce(mockFailedRegisterResponse);
-    (hashPassword as jest.Mock).mockResolvedValue('hashedPassword');
 
     fireEvent.change(phoneInput, { target: { value: '08123456789' } });
     fireEvent.change(firstNameInput, { target: { value: 'John' } });
@@ -121,12 +117,11 @@ describe("Register Page", () => {
     fireEvent.click(registerButton);
 
     await waitFor(() => {
-      expect(hashPassword).toHaveBeenCalledWith('mypassword123');
       expect(handleRegisterSubmit).toHaveBeenCalledWith({
         phone_number: '08123456789',
         first_name: 'John',
         last_name: 'Doe',
-        password: 'hashedPassword'
+        password: 'mypassword123'
       });
       expect(screen.getByText("Registrasi gagal")).toBeInTheDocument();
       expect(mockPush).not.toHaveBeenCalled();
@@ -135,7 +130,6 @@ describe("Register Page", () => {
 
   it("shows error message when there is an error exception during registration", async () => {
     (handleRegisterSubmit as jest.Mock).mockRejectedValue(new Error("Network Error"));
-    (hashPassword as jest.Mock).mockResolvedValue('hashedPassword');
 
     fireEvent.change(phoneInput, { target: { value: '08123456789' } });
     fireEvent.change(firstNameInput, { target: { value: 'John' } });
@@ -144,12 +138,11 @@ describe("Register Page", () => {
     fireEvent.click(registerButton);
 
     await waitFor(() => {
-      expect(hashPassword).toHaveBeenCalledWith('mypassword123');
       expect(handleRegisterSubmit).toHaveBeenCalledWith({
         phone_number: '08123456789',
         first_name: 'John',
         last_name: 'Doe',
-        password: 'hashedPassword'
+        password: 'mypassword123'
       });
       expect(screen.getByText("Terjadi kesalahan pada registrasi")).toBeInTheDocument();
       expect(mockPush).not.toHaveBeenCalled();

--- a/__tests__/pond/[id]/edit.test.tsx
+++ b/__tests__/pond/[id]/edit.test.tsx
@@ -92,6 +92,36 @@ describe('Edit Pond Modal', () => {
     });
   });
 
+  it('displays error message when form submission fails due to an error on the backend', async () => {
+    const mockResponse = { success: false, message: 'Gagal menyimpan kolam' };
+    (addOrUpdatePond as jest.Mock).mockResolvedValue(mockResponse);
+
+    render(<EditPond pond={mockPondData} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit kolam/i }));
+
+    const nameInput = screen.getByPlaceholderText('Nama Kolam');
+    const lengthInput = screen.getByPlaceholderText('Panjang (meter)');
+    const widthInput = screen.getByPlaceholderText('Lebar (meter)');
+    const depthInput = screen.getByPlaceholderText('Kedalaman (meter)');
+    const imageInput = screen.getByTestId('image');
+
+    fireEvent.change(nameInput, { target: { value: 'Updated Pond' } });
+    fireEvent.change(lengthInput, { target: { value: '15' } });
+    fireEvent.change(widthInput, { target: { value: '7' } });
+    fireEvent.change(depthInput, { target: { value: '3' } });
+    fireEvent.change(imageInput, { target: { files: [new File(['(⌐□_□)'], 'pond.jpg', { type: 'image/jpg' })] } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /simpan/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Gagal menyimpan kolam/i)).toBeInTheDocument();
+      expect(addOrUpdatePond).toHaveBeenCalledTimes(1);
+    });
+  })
+
   it('displays error message and sets error state when form submission fails', async () => {
     const mockError = new Error('Gagal menyimpan kolam');
     (addOrUpdatePond as jest.Mock).mockRejectedValueOnce(mockError);

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -9,7 +9,6 @@ import { Input } from "@/components/ui/input";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { loginSchema, LoginForm } from "@/types/auth/login"; 
 import { handleLoginFormSubmit } from "@/lib/auth/login/actions"; 
-import { hashPassword } from "@/lib/auth";
 
 const LoginPage = () => {
   const router = useRouter();

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -26,7 +26,6 @@ const LoginPage = () => {
 
   const onSubmit = async (data: LoginForm) => {
     setError(null)
-    data.password = await hashPassword(data.password)
     const response = await handleLoginFormSubmit(data)
     if (response.ok) {
       reset()

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { handleRegisterSubmit, hashPassword } from '@/lib/auth'
+import { handleRegisterSubmit } from '@/lib/auth'
 import { RegisterForm, registerSchema } from '@/types/auth/register'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
@@ -27,7 +27,6 @@ const RegisterPage = () => {
   const onSubmit = async (data: RegisterForm) => {
     try {
       setError(null)
-      data.password = await hashPassword(data.password)
       const response = await handleRegisterSubmit(data)
 
       if (!response.ok) {

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,5 +1,4 @@
 import { getUser } from "@/lib/auth/user/get-user";
 import { handleRegisterSubmit } from "@/lib/auth/register/registerActions";
-import { hashPassword } from "@/lib/auth/utils";
 
-export { getUser, handleRegisterSubmit, hashPassword };
+export { getUser, handleRegisterSubmit };

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -1,6 +1,0 @@
-import { createHash } from "crypto"
-
-export async function hashPassword(password: string): Promise<string> {
-  const hashedPassword = createHash("sha256").update(password).digest("hex")
-  return hashedPassword
-}


### PR DESCRIPTION
Previously, I added hashing in register and login passwords. However, that was unnecessary and also gives much more complexity to the code which increases run time and make it hard for you to use the same account in postman and in the actual environment. Also, if you just created/register an account in recent times, you might want to create another one after this request is merged to staging

I also added  a test for unsuccessful response from the backend in the EditPondForm to make the coverage 100%. I don't know why but it was just recognized as a non covered block which was covered before.