### PR TITLE
Refactor Pond Quality

### DIFF
--- a/__tests__/food_sampling/FoodSamplingForm.test.tsx
+++ b/__tests__/food_sampling/FoodSamplingForm.test.tsx
@@ -17,7 +17,7 @@ describe('FoodSamplingForm', () => {
     pond_id: pondId,
     cycle_id: cycleId,
     food_quantity: 30,
-    sample_date: '2024-10-01',
+    sample_date: new Date('2024-10-01'),
   };
 
   beforeEach(() => {

--- a/__tests__/pond-quality/add.quality.test.tsx
+++ b/__tests__/pond-quality/add.quality.test.tsx
@@ -12,6 +12,7 @@ describe('Add Pond Quality Modal', () => {
     id: '1',
     pond: '1',
     reporter: '082299442770',
+    cycle: 'cycle123',
     recorded_at: new Date(),
     ph_level: 7,
     salinity: 30,
@@ -27,13 +28,14 @@ describe('Add Pond Quality Modal', () => {
   };
 
   const pondId = 'test-pond-id';
+  const cycleId = 'test-cycle-id';
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders the form fields correctly', async () => {
-    render(<AddPondQuality pondId={pondId}  />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId} />);
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
@@ -63,7 +65,7 @@ describe('Add Pond Quality Modal', () => {
     const mockResponse = { success: true, message: 'Pond quality added' };
     (addOrUpdatePondQuality as jest.Mock).mockResolvedValue(mockResponse);
 
-    render(<AddPondQuality pondId={pondId} />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId}/>);
 
     fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
 
@@ -93,7 +95,7 @@ describe('Add Pond Quality Modal', () => {
     (addOrUpdatePondQuality as jest.Mock).mockResolvedValue(mockResponse);
     const file = new File(['(⌐□_□)'], 'pond.jpg', { type: 'image/jpg' });
   
-    render(<AddPondQuality pondId={pondId} />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId}/>);
   
     fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
   
@@ -125,7 +127,7 @@ describe('Add Pond Quality Modal', () => {
     (addOrUpdatePondQuality as jest.Mock).mockRejectedValueOnce(mockError);
 
 
-    render(<AddPondQuality pondId={pondId} />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId}/>);
 
     fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
 
@@ -149,7 +151,7 @@ describe('Add Pond Quality Modal', () => {
   });
 
   it('does not allow form submission when any of the fields are invalid', async () => {
-    render(<AddPondQuality pondId={pondId} />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId}/>);
 
     fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
 
@@ -168,7 +170,7 @@ describe('Add Pond Quality Modal', () => {
   });
 
   it('handles file input correctly', async () => {
-    render(<AddPondQuality pondId={pondId} />);
+    render(<AddPondQuality pondId={pondId} cycleId={cycleId}/>);
 
     fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));
 
@@ -186,7 +188,7 @@ describe('Add Pond Quality Modal', () => {
   });
 
   it('displays the previous added values in the form fields', async () => {
-    render(<AddPondQuality pondId={pondId} pondQuality={mockPondQualityData} />);
+    render(<AddPondQuality pondId={pondId} pondQuality={mockPondQualityData} cycleId={cycleId}/>);
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Add Pond Quality/i }));

--- a/__tests__/pond/[id]/detail.test.tsx
+++ b/__tests__/pond/[id]/detail.test.tsx
@@ -41,6 +41,7 @@ const mockPondQuality: PondQuality = {
   id: 'abcde',
   pond: 'abcde',
   reporter: '081234567890',
+  cycle: 'cycle123',
   recorded_at: new Date(),
   image_name: 'pond1.jpg',
   ph_level: 7.5,

--- a/app/pond/[id]/page.tsx
+++ b/app/pond/[id]/page.tsx
@@ -40,7 +40,7 @@ const PondDetailPage = async ({ params }: { params: { id: string } }) => {
   }
 
   try {
-    pondQuality = await getLatestPondQuality(params.id)
+    pondQuality = await getLatestPondQuality(params.id, cycle?.id ?? '')
   } catch (error) {
     pondQuality = undefined
   }
@@ -88,7 +88,8 @@ const PondDetailPage = async ({ params }: { params: { id: string } }) => {
           <PondQualityList pondQuality={pondQuality} />
           
           <div className="mt-4">
-            <AddPondQuality pondId={pond.pond_id} pondQuality={pondQuality}/>
+            {cycle !== undefined ? (<AddPondQuality pondId={pond.pond_id} pondQuality={pondQuality} cycleId= {cycle.id}/>) :
+            <p>Tidak dapat menambahkan kualitas kolam karena siklus belum ada</p>}
           </div>
         </div>
         <div className='flex flex-col mt-10'>
@@ -99,13 +100,13 @@ const PondDetailPage = async ({ params }: { params: { id: string } }) => {
           </div>
         </div>
         <div className='flex flex-col mt-10'>
-          <div className="mt-4">
-            {cycle !== undefined ? (<AddFoodSampling pondId={pond.pond_id} cycleId= {cycle.id} />):
-            <p>Tidak dapat menambahkan sample makanan karena siklus belum ada</p>}
-          </div>
+          <FoodSamplingList foodSampling={foodSampling} />
         </div>
         <div className='flex flex-col mt-10'>
-          <FoodSamplingList foodSampling={foodSampling} />
+          <div className="mt-4">
+            {cycle !== undefined ? (<AddFoodSampling pondId={pond.pond_id} cycleId={cycle.id} />):
+            <p>Tidak dapat menambahkan sample makanan karena siklus belum ada</p>}
+          </div>
         </div>
       </div>
     </div>

--- a/components/pond-quality/AddPondQuality.tsx
+++ b/components/pond-quality/AddPondQuality.tsx
@@ -11,10 +11,11 @@ import { PondQuality } from '@/types/pond-quality';
 interface AddPondQualityProps extends React.HTMLAttributes<HTMLDivElement> {
   pondId: string;
   pondQuality?: PondQuality;
+  cycleId: string;
 }
 
 
-const AddPondQuality: React.FC<AddPondQualityProps> = ({pondId, pondQuality, ...props}) =>  {
+const AddPondQuality: React.FC<AddPondQualityProps> = ({pondId, pondQuality, cycleId, ...props}) =>  {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -26,7 +27,7 @@ const AddPondQuality: React.FC<AddPondQualityProps> = ({pondId, pondQuality, ...
           </Button>
         </DialogTrigger>
         <DialogContent title="Add Pond Quality">
-          <PondQualityForm setIsModalOpen={setIsModalOpen} pondId={pondId} pondQuality={pondQuality}/>
+          <PondQualityForm setIsModalOpen={setIsModalOpen} pondId={pondId} pondQuality={pondQuality} cycleId={cycleId}/>
         </DialogContent>
       </Dialog>
     </div>

--- a/components/pond-quality/PondQualityForm.tsx
+++ b/components/pond-quality/PondQualityForm.tsx
@@ -13,10 +13,11 @@ interface PondQualityFormProps {
   setIsModalOpen: (open: boolean) => void
   pondQuality?: PondQuality
   pondId?: string
+  cycleId?: string
   
 }
 
-const PondQualityForm: React.FC<PondQualityFormProps> = ({pondId, pondQuality, setIsModalOpen }) => {
+const PondQualityForm: React.FC<PondQualityFormProps> = ({pondId, pondQuality, cycleId ,setIsModalOpen }) => {
     const [error, setError] = useState<string | null>(null)
 
   
@@ -53,7 +54,7 @@ const PondQualityForm: React.FC<PondQualityFormProps> = ({pondId, pondQuality, s
       data.image = imageList[0]
       const formQualityData = objectToFormData(data)
 
-      const res = await addOrUpdatePondQuality(formQualityData, pondId)
+      const res = await addOrUpdatePondQuality(formQualityData, pondId, cycleId)
 
       if (!res.success) {
         setError('Gagal menyimpan kualitas air')

--- a/lib/pond-quality/getLatestPondQuality.ts
+++ b/lib/pond-quality/getLatestPondQuality.ts
@@ -5,11 +5,11 @@ import { cookies } from "next/headers";
 
 const API_BASE_URL = process.env.API_BASE_URL;
 
-export async function getLatestPondQuality(pondId: string): Promise<PondQuality | undefined> {
+export async function getLatestPondQuality(pondId: string, cycleId: string): Promise<PondQuality | undefined> {
   const token = cookies().get("accessToken")?.value;
 
   try {
-    const res = await fetch(`${API_BASE_URL}/api/pond-quality/${pondId}/latest`, {
+    const res = await fetch(`${API_BASE_URL}/api/pond-quality/${cycleId}/${pondId}/latest`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/lib/pond-quality/getPondQuality.ts
+++ b/lib/pond-quality/getPondQuality.ts
@@ -4,10 +4,10 @@ import { cookies } from "next/headers"
 
 const API_BASE_URL = process.env.API_BASE_URL
 
-export async function getPondQuality(pondId: string, pondQualityId: string) {
+export async function getPondQuality(pondId: string, pondQualityId: string, cycleId: string) {
   const token = cookies().get('accessToken')?.value
   try {
-    const response = await fetch(`${API_BASE_URL}/api/pond-quality/${pondId}/${pondQualityId}/`, {
+    const response = await fetch(`${API_BASE_URL}/api/pond-quality/${cycleId}/${pondId}/${pondQualityId}/`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/lib/pond-quality/updatePondQuality.ts
+++ b/lib/pond-quality/updatePondQuality.ts
@@ -6,20 +6,21 @@ import { formDataToObject, hashImageName } from "@/lib/utils";
 export async function addOrUpdatePondQuality(
   data: FormData,
   pondId?: string,
+  cycleId?: string,
   pondQualityId?: string
 ): Promise<{ success: boolean; message?: string }> {
   const token = cookies().get('accessToken')?.value;
 
   const baseUrl = process.env.API_BASE_URL;
   const qualityPath = pondQualityId ? pondQualityId + '/' : '';
-  const apiUrl = `${baseUrl}/api/pond-quality/${pondId}/${qualityPath}`;
+  const apiUrl = `${baseUrl}/api/pond-quality/${cycleId}/${pondId}/${qualityPath}`;
 
-  const image: File = data.get('image') as File
-  const pondQualityData = formDataToObject(data)
+  const image: File = data.get('image') as File;
+  const pondQualityData = formDataToObject(data);
 
-  let hashedImageName = ''
+  let hashedImageName = '';
   if (image.name) {
-    hashedImageName = await hashImageName(image.name)
+    hashedImageName = await hashImageName(image.name);
   }
 
   const response = await fetch(apiUrl, {

--- a/types/pond-quality/pond-quality.ts
+++ b/types/pond-quality/pond-quality.ts
@@ -2,6 +2,7 @@ export type PondQuality = {
   id: string
   pond: string
   reporter: string
+  cycle: string
   recorded_at: Date
   image_name: string
   ph_level: number


### PR DESCRIPTION
I refactored the Pond Quality feature so that it connects to cycle. So when there is no cycle running, you can access the pond quality form and you cant fill out the modal. In order to access it, one must create a cycle first and fill out the fish amount on the pond and then start the cycle. And only then, when there is currently an active cycle, user can fill out the pond quality forms.